### PR TITLE
Add Admin Mode with teacher login and protected enrollment

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,11 +1,12 @@
 # Mergington High School Activities API
 
-A super simple FastAPI application that allows students to view and sign up for extracurricular activities.
+A super simple FastAPI application that allows students to view extracurricular activities and teachers to manage registrations.
 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher login and logout flow
+- Teacher-only sign up and unregister operations
 
 ## Getting Started
 
@@ -29,8 +30,20 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| GET    | `/activities`                                                     | Get all activities with details and participant lists               |
+| POST   | `/auth/login?username=teacher.alvarez&password=classroom123`     | Log in as teacher and get an auth token                             |
+| POST   | `/auth/logout?token={token}`                                     | Log out the active teacher session                                  |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu&token={token}` | Sign up a student for an activity (teacher only)                    |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu&token={token}` | Unregister a student from an activity (teacher only)                |
+
+## Teacher Credentials
+
+Teacher usernames and passwords are stored in `teachers.json` and validated by the backend.
+
+Example entries:
+
+- `teacher.alvarez` / `classroom123`
+- `teacher.khan` / `robotics456`
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,8 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+from uuid import uuid4
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +20,14 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+teachers_file = current_dir / "teachers.json"
+
+with teachers_file.open("r", encoding="utf-8") as file:
+    TEACHER_CREDENTIALS = json.load(file)
+
+# In-memory session tokens for logged-in teachers.
+active_teacher_sessions = {}
 
 # In-memory activity database
 activities = {
@@ -88,9 +98,32 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def login_teacher(username: str, password: str):
+    """Login endpoint for teachers only"""
+    expected_password = TEACHER_CREDENTIALS.get(username)
+    if expected_password is None or expected_password != password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = str(uuid4())
+    active_teacher_sessions[token] = username
+    return {"message": "Login successful", "token": token, "username": username}
+
+
+@app.post("/auth/logout")
+def logout_teacher(token: str):
+    """Logout endpoint for teachers"""
+    if token in active_teacher_sessions:
+        del active_teacher_sessions[token]
+    return {"message": "Logged out"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, token: str):
     """Sign up a student for an activity"""
+    if token not in active_teacher_sessions:
+        raise HTTPException(status_code=401, detail="Teacher login required")
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +144,11 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, token: str):
     """Unregister a student from an activity"""
+    if token not in active_teacher_sessions:
+        raise HTTPException(status_code=401, detail="Teacher login required")
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,52 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const userMenuButton = document.getElementById("user-menu-button");
+  const closeLoginModalButton = document.getElementById("close-login-modal");
+  const logoutButton = document.getElementById("logout-button");
+  const authStatus = document.getElementById("auth-status");
+  const teacherHint = document.getElementById("teacher-hint");
+
+  let authToken = localStorage.getItem("teacherAuthToken") || "";
+  let loggedInTeacher = localStorage.getItem("teacherUsername") || "";
+
+  function setMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function isTeacherLoggedIn() {
+    return authToken.length > 0;
+  }
+
+  function refreshAuthUI() {
+    const teacherLoggedIn = isTeacherLoggedIn();
+
+    signupForm.querySelectorAll("input, select, button").forEach((element) => {
+      element.disabled = !teacherLoggedIn;
+    });
+
+    authStatus.textContent = teacherLoggedIn
+      ? `Teacher: ${loggedInTeacher}`
+      : "Student View";
+    teacherHint.classList.toggle("hidden", teacherLoggedIn);
+    logoutButton.classList.toggle("hidden", !teacherLoggedIn);
+  }
+
+  function openLoginModal() {
+    loginModal.classList.remove("hidden");
+  }
+
+  function closeLoginModal() {
+    loginModal.classList.add("hidden");
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +58,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +77,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}" ${
+                        isTeacherLoggedIn() ? "" : "disabled"
+                      }>❌</button></li>`
                   )
                   .join("")}
               </ul>
@@ -60,6 +109,8 @@ document.addEventListener("DOMContentLoaded", () => {
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
+
+      refreshAuthUI();
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -69,6 +120,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!isTeacherLoggedIn()) {
+      setMessage("Teacher login required", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -77,7 +133,9 @@ document.addEventListener("DOMContentLoaded", () => {
       const response = await fetch(
         `/activities/${encodeURIComponent(
           activity
-        )}/unregister?email=${encodeURIComponent(email)}`,
+        )}/unregister?email=${encodeURIComponent(email)}&token=${encodeURIComponent(
+          authToken
+        )}`,
         {
           method: "DELETE",
         }
@@ -86,26 +144,15 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        setMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        setMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      setMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -114,6 +161,11 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!isTeacherLoggedIn()) {
+      setMessage("Teacher login required", "error");
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
@@ -121,7 +173,9 @@ document.addEventListener("DOMContentLoaded", () => {
       const response = await fetch(
         `/activities/${encodeURIComponent(
           activity
-        )}/signup?email=${encodeURIComponent(email)}`,
+        )}/signup?email=${encodeURIComponent(email)}&token=${encodeURIComponent(
+          authToken
+        )}`,
         {
           method: "POST",
         }
@@ -130,31 +184,86 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        setMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        setMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      setMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("teacher-username").value;
+    const password = document.getElementById("teacher-password").value;
+
+    try {
+      const response = await fetch(
+        `/auth/login?username=${encodeURIComponent(
+          username
+        )}&password=${encodeURIComponent(password)}`,
+        { method: "POST" }
+      );
+      const result = await response.json();
+
+      if (response.ok) {
+        authToken = result.token;
+        loggedInTeacher = result.username;
+        localStorage.setItem("teacherAuthToken", authToken);
+        localStorage.setItem("teacherUsername", loggedInTeacher);
+        refreshAuthUI();
+        closeLoginModal();
+        setMessage(result.message, "success");
+        fetchActivities();
+        loginForm.reset();
+      } else {
+        setMessage(result.detail || "Login failed", "error");
+      }
+    } catch (error) {
+      setMessage("Failed to log in. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutButton.addEventListener("click", async () => {
+    if (!isTeacherLoggedIn()) {
+      return;
+    }
+
+    try {
+      await fetch(`/auth/logout?token=${encodeURIComponent(authToken)}`, {
+        method: "POST",
+      });
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+
+    authToken = "";
+    loggedInTeacher = "";
+    localStorage.removeItem("teacherAuthToken");
+    localStorage.removeItem("teacherUsername");
+    refreshAuthUI();
+    closeLoginModal();
+    setMessage("Logged out", "success");
+    fetchActivities();
+  });
+
+  userMenuButton.addEventListener("click", openLoginModal);
+  closeLoginModalButton.addEventListener("click", closeLoginModal);
+  loginModal.addEventListener("click", (event) => {
+    if (event.target === loginModal) {
+      closeLoginModal();
+    }
+  });
+
   // Initialize app
+  refreshAuthUI();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,12 @@
   </head>
   <body>
     <header>
+      <div class="user-menu">
+        <button id="user-menu-button" class="user-menu-button" type="button" aria-label="Open user menu">
+          <span class="user-icon">👤</span>
+          <span id="auth-status" class="auth-status">Student View</span>
+        </button>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
@@ -22,7 +28,7 @@
       </section>
 
       <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+        <h3>Teacher Activity Management</h3>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -37,9 +43,31 @@
           </div>
           <button type="submit">Sign Up</button>
         </form>
+        <p id="teacher-hint" class="info-text">Teachers must log in to register or unregister students.</p>
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-title">
+      <div class="modal-content">
+        <h3 id="login-title">Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Log In</button>
+            <button id="logout-button" type="button" class="secondary hidden">Log Out</button>
+            <button id="close-login-modal" type="button" class="secondary">Close</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <footer>
       <p>&copy; 2023 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,6 +16,7 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
@@ -26,6 +27,35 @@ header {
 
 header h1 {
   margin-bottom: 10px;
+}
+
+.user-menu {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.user-menu-button {
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+}
+
+.user-menu-button:hover {
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.user-icon {
+  font-size: 16px;
+}
+
+.auth-status {
+  font-size: 14px;
 }
 
 main {
@@ -125,6 +155,11 @@ section h3 {
   background-color: #ffebee;
 }
 
+.delete-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .participants-section p {
   color: #777;
   font-style: italic;
@@ -162,6 +197,57 @@ button {
 
 button:hover {
   background-color: #3949ab;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.secondary {
+  background-color: #e8eaf6;
+  color: #1a237e;
+}
+
+.secondary:hover {
+  background-color: #c5cae9;
+}
+
+.info-text {
+  margin-top: 10px;
+  font-size: 14px;
+  color: #455a64;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: 20;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 420px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 10px 35px rgba(0, 0, 0, 0.25);
+}
+
+.modal-content h3 {
+  margin-bottom: 16px;
+  color: #1a237e;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .message {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+{
+  "teacher.alvarez": "classroom123",
+  "teacher.khan": "robotics456"
+}


### PR DESCRIPTION
## Summary
Implements **Admin Mode** so only logged-in teachers can register/unregister students.

## Changes
- Added teacher authentication endpoints:
  - `POST /auth/login`
  - `POST /auth/logout`
- Protected enrollment endpoints with teacher session token:
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Added `src/teachers.json` for backend-managed teacher credentials.
- Updated frontend with:
  - Top-right user icon/status
  - Teacher login modal
  - Disabled signup/unregister actions until teacher login
- Updated API docs in `src/README.md`.

## Notes
- Session storage is currently in-memory and resets on backend restart.
- Existing activity viewing remains available for non-logged-in users.

Closes #5